### PR TITLE
Update in update_board and added flip & flip_neighbour

### DIFF
--- a/src/FastBoard.cpp
+++ b/src/FastBoard.cpp
@@ -151,16 +151,31 @@ void FastBoard::reset_board(const int size) {
         for (int j = 0; j < size; j++) {
             int vertex = get_vertex(i, j);
 
-            // Sets up the vertex state as empty.
-            m_state[vertex] = EMPTY;
-            // Since m_empty_cnt is used as the position in the
-            // m_empty vector, where all the empty vertexes are
-            // stored, you can use this to find the index of the
-            // vertex in m_empty.
-            m_empty_idx[vertex] = m_empty_cnt;
-            // Adds the vertex to the list of empty ones, then
-            // increased the m_empty_cnt value.
-            m_empty[m_empty_cnt++] = vertex;
+            if constexpr (IS_OTHELLO) {
+                if ((i == size / 2 - 1 && j == size / 2 - 1) || (i == size / 2 && j == size / 2)) {
+                    //Place two black pawns (BLACK) in the centre
+                    m_state[vertex] = BLACK; 
+                } else if ((i == size / 2 && j == size / 2 - 1) || (i == size / 2 - 1 && j == size / 2)) {
+                    //Place two white pawns (WHITE) in the centre
+                    m_state[vertex] = WHITE; 
+                } else { 
+                    //The other boxes are initialised as empty (EMPTY).
+                    m_state[vertex] = EMPTY;
+                    m_empty_idx[vertex] = m_empty_cnt;
+                    m_empty[m_empty_cnt++] = vertex; 
+                }
+            } else { //
+                // Sets up the vertex state as empty.
+                m_state[vertex] = EMPTY;
+                // Since m_empty_cnt is used as the position in the
+                // m_empty vector, where all the empty vertexes are
+                // stored, you can use this to find the index of the
+                // vertex in m_empty.
+                m_empty_idx[vertex] = m_empty_cnt;
+                // Adds the vertex to the list of empty ones, then
+                // increased the m_empty_cnt value.
+                m_empty[m_empty_cnt++] = vertex;
+            }
 
             // Checks if it's on the top or bottom edge.
             if (i == 0 || i == size - 1) {

--- a/src/FastBoard.cpp
+++ b/src/FastBoard.cpp
@@ -176,7 +176,7 @@ void FastBoard::reset_board(const int size) {
                 // increased the m_empty_cnt value.
                 m_empty[m_empty_cnt++] = vertex;
             }
-
+            
             // Checks if it's on the top or bottom edge.
             if (i == 0 || i == size - 1) {
                 m_neighbours[vertex] += (1 << (NBR_SHIFT * BLACK))
@@ -290,6 +290,23 @@ void FastBoard::add_neighbour(const int vtx, const int color) {
             nbr_pars[nbr_par_cnt++] = m_parent[ai];
         }
     }
+}
+
+void FastBoard::flip_neighbour(const int vtx, const int color) { //instead of removing empty spaces when adding a new pawn, we want to flip to the new color
+    assert(color == WHITE || color == BLACK || color == EMPTY);
+    
+    for (int k = 0; k < 8; k++) {
+        int ai = vtx + m_dirs[k]; //iterates on its neighbours
+        if (color == BLACK) {
+            m_neighbours[ai] += (1 << (NBR_SHIFT * color))
+                - (1 << (NBR_SHIFT * WHITE)); //removes a white, adds a black
+        }
+        if (color == WHITE) {
+            m_neighbours[ai] += (1 << (NBR_SHIFT * color))
+                - (1 << (NBR_SHIFT * BLACK)); //removes a black, adds a white
+        }
+    }
+    
 }
 
 // Removes a vertex, which means it needs to update all its neighbors' data.

--- a/src/FastBoard.h
+++ b/src/FastBoard.h
@@ -136,6 +136,7 @@ protected:
     int count_neighbours(int color, int i) const;
     void merge_strings(int ip, int aip);
     void add_neighbour(int i, int color);
+    void flip_neighbour(int i, int color);
     void remove_neighbour(int i, int color);
     void print_columns();
 };

--- a/src/FullBoard.h
+++ b/src/FullBoard.h
@@ -50,6 +50,7 @@ public:
 
     std::uint64_t calc_hash(int komove = NO_VERTEX) const;
     std::uint64_t calc_symmetry_hash(int komove, int symmetry) const;
+    void flip(int starting, int end, int dir);
     std::uint64_t calc_ko_hash() const;
 
     std::uint64_t m_hash;


### PR DESCRIPTION
The "update_board" code has been updated so that it works for both Go and Othello.
Consequently, the "flip" function was added in FullBoard.cpp, which in turn calls "flip_neighbour" in FastBoard.cpp
Finally, declarations of these functions were added in the specific .h file